### PR TITLE
fiu0_drd_cfg and fiu_clk_divider comand line support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,10 @@ sudo make install
 ## Usage
 
 ```bash
-create_image [--bootblock | --uboot] [input file] [output file]
+create_image <--bootblock | --uboot>
+             [--fiu0_drd_cfg=M] [--fiu_clk_divider=N]
+             <input file> <output file>
 ```
+
+Where `M` is an unsigned hexadecimal number which will fit in 32 bits and `N` is
+a unsigned hexadecimal number which will fit in 8 bits.


### PR DESCRIPTION
The fiu0_drd_cfg and fiu_clk_divider parameter values depend on connected flash devices and may need to be set to different values depending on a particular board. This set of changes allows the values to be set via command line. The new flags are optional and have the same default behavior as before if not provided.